### PR TITLE
Preserve live tab view state and prioritize leak insights

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -47,32 +47,34 @@ type AppMetadata struct {
 
 // App is the main application controller
 type App struct {
-	ctx            context.Context
-	cancel         context.CancelFunc
-	fyneApp        fyne.App
-	win            fyne.Window
-	logPath        string
-	service        appService
-	watcher        *watcher.LogWatcher
-	watcherGen     uint64
-	changeReqCh    chan string
-	workerStopCh   chan struct{}
-	workerWG       sync.WaitGroup
-	closeOnce      sync.Once
-	isShuttingDown bool
-	mu             sync.Mutex
-	lastStats      *stats.Stats
-	lastHands      []*parser.Hand
-	lastLocalSeat  int
-	rangeState     *HandRangeViewState
-	historyState   *HandHistoryViewState
-	metricState    *MetricVisibilityState
-	settingsTab    fyne.CanvasObject
-	settingsPath   string
-	overviewView   *overviewTabView
-	positionView   *positionStatsTabView
-	currentTab     appTab
-	navExpanded    bool
+	ctx             context.Context
+	cancel          context.CancelFunc
+	fyneApp         fyne.App
+	win             fyne.Window
+	logPath         string
+	service         appService
+	watcher         *watcher.LogWatcher
+	watcherGen      uint64
+	changeReqCh     chan string
+	workerStopCh    chan struct{}
+	workerWG        sync.WaitGroup
+	closeOnce       sync.Once
+	isShuttingDown  bool
+	mu              sync.Mutex
+	lastStats       *stats.Stats
+	lastHands       []*parser.Hand
+	lastLocalSeat   int
+	rangeState      *HandRangeViewState
+	historyState    *HandHistoryViewState
+	metricState     *MetricVisibilityState
+	settingsTab     fyne.CanvasObject
+	settingsPath    string
+	overviewView    *overviewTabView
+	positionView    *positionStatsTabView
+	handRangeView   *handRangeTabView
+	handHistoryView *handHistoryTabView
+	currentTab      appTab
+	navExpanded     bool
 
 	mainContent *fyne.Container
 	railPanel   *fyne.Container
@@ -495,9 +497,17 @@ func (a *App) doRefreshCurrentTab() {
 		a.positionView.Update(s)
 		obj = a.positionView.CanvasObject()
 	case tabHandRange:
-		obj = NewHandRangeTab(s, a.win, a.rangeState)
+		if a.handRangeView == nil {
+			a.handRangeView = newHandRangeTabView(a.win, a.rangeState)
+		}
+		a.handRangeView.Update(s)
+		obj = a.handRangeView.CanvasObject()
 	case tabHandHistory:
-		obj = NewHandHistoryTab(hands, localSeat, a.historyState)
+		if a.handHistoryView == nil {
+			a.handHistoryView = newHandHistoryTabView(a.historyState)
+		}
+		a.handHistoryView.Update(hands, localSeat)
+		obj = a.handHistoryView.CanvasObject()
 	case tabSettings:
 		if a.settingsTab == nil || a.settingsPath != path {
 			a.settingsTab = NewSettingsTab(

--- a/internal/ui/overview.go
+++ b/internal/ui/overview.go
@@ -160,6 +160,9 @@ func NewOverviewTab(s *stats.Stats, visibility *MetricVisibilityState, win fyne.
 	sections := []fyne.CanvasObject{
 		container.NewVBox(title, subtitle),
 		newSectionDivider(),
+		widget.NewLabelWithStyle(lang.X("overview.section.insights", "Leak Insights"), fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
+		container.NewVBox(insightRows...),
+		newSectionDivider(),
 		widget.NewLabelWithStyle(lang.X("overview.section.key_metrics", "Key Metrics"), fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 	}
 
@@ -174,12 +177,6 @@ func NewOverviewTab(s *stats.Stats, visibility *MetricVisibilityState, win fyne.
 			container.NewGridWithColumns(minInt(3, len(otherCards)), otherCards...),
 		)
 	}
-
-	sections = append(sections,
-		newSectionDivider(),
-		widget.NewLabelWithStyle(lang.X("overview.section.insights", "Leak Insights"), fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
-		container.NewVBox(insightRows...),
-	)
 
 	content := container.NewPadded(container.NewVBox(sections...))
 	return withFixedLowSampleLegend(container.NewScroll(content))

--- a/internal/ui/tab_views.go
+++ b/internal/ui/tab_views.go
@@ -3,9 +3,98 @@ package ui
 import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/widget"
 
+	"github.com/AkatukiSora/vrc-vrpoker-ststs/internal/parser"
 	"github.com/AkatukiSora/vrc-vrpoker-ststs/internal/stats"
 )
+
+type viewLayoutState struct {
+	scrollOffsets []fyne.Position
+	splitOffsets  []float64
+	listOffsets   []float32
+}
+
+func captureViewLayoutState(obj fyne.CanvasObject) viewLayoutState {
+	state := viewLayoutState{}
+	collectViewLayoutState(obj, &state)
+	return state
+}
+
+func collectViewLayoutState(obj fyne.CanvasObject, state *viewLayoutState) {
+	if obj == nil || state == nil {
+		return
+	}
+
+	switch o := obj.(type) {
+	case *container.Scroll:
+		state.scrollOffsets = append(state.scrollOffsets, o.Offset)
+		collectViewLayoutState(o.Content, state)
+	case *container.Split:
+		state.splitOffsets = append(state.splitOffsets, o.Offset)
+		collectViewLayoutState(o.Leading, state)
+		collectViewLayoutState(o.Trailing, state)
+	case *fyne.Container:
+		for _, child := range o.Objects {
+			collectViewLayoutState(child, state)
+		}
+	case *widget.List:
+		state.listOffsets = append(state.listOffsets, o.GetScrollOffset())
+	}
+}
+
+func applyViewLayoutState(obj fyne.CanvasObject, state viewLayoutState) {
+	scrollIdx := 0
+	splitIdx := 0
+	listIdx := 0
+	applyViewLayoutStateRecursive(obj, state, &scrollIdx, &splitIdx, &listIdx)
+}
+
+func applyViewLayoutStateRecursive(obj fyne.CanvasObject, state viewLayoutState, scrollIdx, splitIdx, listIdx *int) {
+	if obj == nil {
+		return
+	}
+
+	switch o := obj.(type) {
+	case *container.Scroll:
+		if *scrollIdx < len(state.scrollOffsets) {
+			o.Offset = state.scrollOffsets[*scrollIdx]
+		}
+		(*scrollIdx)++
+		applyViewLayoutStateRecursive(o.Content, state, scrollIdx, splitIdx, listIdx)
+	case *container.Split:
+		if *splitIdx < len(state.splitOffsets) {
+			o.Offset = state.splitOffsets[*splitIdx]
+		}
+		(*splitIdx)++
+		applyViewLayoutStateRecursive(o.Leading, state, scrollIdx, splitIdx, listIdx)
+		applyViewLayoutStateRecursive(o.Trailing, state, scrollIdx, splitIdx, listIdx)
+	case *fyne.Container:
+		for _, child := range o.Objects {
+			applyViewLayoutStateRecursive(child, state, scrollIdx, splitIdx, listIdx)
+		}
+	case *widget.List:
+		if *listIdx < len(state.listOffsets) {
+			o.ScrollToOffset(state.listOffsets[*listIdx])
+		}
+		(*listIdx)++
+	}
+}
+
+func replaceViewContentPreservingLayout(root *fyne.Container, next fyne.CanvasObject) {
+	if root == nil {
+		return
+	}
+
+	var state viewLayoutState
+	if len(root.Objects) > 0 {
+		state = captureViewLayoutState(root.Objects[0])
+	}
+
+	root.Objects = []fyne.CanvasObject{next}
+	applyViewLayoutState(next, state)
+	root.Refresh()
+}
 
 type overviewTabView struct {
 	root       *fyne.Container
@@ -18,8 +107,7 @@ func newOverviewTabView(win fyne.Window, visibility *MetricVisibilityState) *ove
 }
 
 func (v *overviewTabView) Update(s *stats.Stats) {
-	v.root.Objects = []fyne.CanvasObject{NewOverviewTab(s, v.visibility, v.win)}
-	v.root.Refresh()
+	replaceViewContentPreservingLayout(v.root, NewOverviewTab(s, v.visibility, v.win))
 }
 
 func (v *overviewTabView) CanvasObject() fyne.CanvasObject {
@@ -36,10 +124,44 @@ func newPositionStatsTabView(visibility *MetricVisibilityState) *positionStatsTa
 }
 
 func (v *positionStatsTabView) Update(s *stats.Stats) {
-	v.root.Objects = []fyne.CanvasObject{NewPositionStatsTab(s, v.visibility)}
-	v.root.Refresh()
+	replaceViewContentPreservingLayout(v.root, NewPositionStatsTab(s, v.visibility))
 }
 
 func (v *positionStatsTabView) CanvasObject() fyne.CanvasObject {
+	return v.root
+}
+
+type handRangeTabView struct {
+	root  *fyne.Container
+	win   fyne.Window
+	state *HandRangeViewState
+}
+
+func newHandRangeTabView(win fyne.Window, state *HandRangeViewState) *handRangeTabView {
+	return &handRangeTabView{root: container.NewMax(), win: win, state: state}
+}
+
+func (v *handRangeTabView) Update(s *stats.Stats) {
+	replaceViewContentPreservingLayout(v.root, NewHandRangeTab(s, v.win, v.state))
+}
+
+func (v *handRangeTabView) CanvasObject() fyne.CanvasObject {
+	return v.root
+}
+
+type handHistoryTabView struct {
+	root  *fyne.Container
+	state *HandHistoryViewState
+}
+
+func newHandHistoryTabView(state *HandHistoryViewState) *handHistoryTabView {
+	return &handHistoryTabView{root: container.NewMax(), state: state}
+}
+
+func (v *handHistoryTabView) Update(hands []*parser.Hand, localSeat int) {
+	replaceViewContentPreservingLayout(v.root, NewHandHistoryTab(hands, localSeat, v.state))
+}
+
+func (v *handHistoryTabView) CanvasObject() fyne.CanvasObject {
 	return v.root
 }


### PR DESCRIPTION
## Summary
- Preserve UI viewport state across watcher-driven refreshes by capturing/restoring `Scroll`, `List`, and `Split` offsets when tab content is rebuilt.
- Convert Hand Range and Hand History tabs to persistent view wrappers so live updates no longer reset interaction context.
- Move Overview leak insights to the top section so the primary analysis signal is visible first.

## Verification
- go test ./...