### PR TITLE
Track new VRChat session logs by auto-switching watcher

### DIFF
--- a/internal/ui/app.go
+++ b/internal/ui/app.go
@@ -386,6 +386,12 @@ func (a *App) changeLogFile(path string) {
 		}
 		a.doUpdateStats()
 	}
+	w.OnNewLogFile = func(nextPath string) {
+		if !a.isCurrentWatcherGeneration(gen) {
+			return
+		}
+		a.requestLogFileChange(nextPath)
+	}
 	w.OnError = func(err error) {
 		if !a.isCurrentWatcherGeneration(gen) {
 			return

--- a/internal/watcher/watcher_test.go
+++ b/internal/watcher/watcher_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 func TestLogWatcherStopIsIdempotent(t *testing.T) {
@@ -21,4 +22,85 @@ func TestLogWatcherStopIsIdempotent(t *testing.T) {
 
 	lw.Stop()
 	lw.Stop()
+}
+
+func TestLogWatcherDetectsNewSessionLogOnCreate(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	currentLogPath := filepath.Join(dir, "output_log_2026-02-21_00-00-00.txt")
+	if err := os.WriteFile(currentLogPath, []byte(""), 0o600); err != nil {
+		t.Fatalf("write current log: %v", err)
+	}
+
+	lw, err := NewLogWatcher(currentLogPath)
+	if err != nil {
+		t.Fatalf("new watcher: %v", err)
+	}
+	defer lw.Stop()
+
+	newLogCh := make(chan string, 1)
+	lw.OnNewLogFile = func(path string) {
+		select {
+		case newLogCh <- path:
+		default:
+		}
+	}
+
+	if err := lw.Start(); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+
+	newLogPath := filepath.Join(dir, "output_log_2026-02-21_00-10-00.txt")
+	if err := os.WriteFile(newLogPath, []byte("new session"), 0o600); err != nil {
+		t.Fatalf("write new log: %v", err)
+	}
+
+	select {
+	case got := <-newLogCh:
+		if filepath.Clean(got) != filepath.Clean(newLogPath) {
+			t.Fatalf("detected path = %q, want %q", got, newLogPath)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatalf("timed out waiting for new log file detection")
+	}
+}
+
+func TestLogWatcherIgnoresNonVRChatCreatedFiles(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	currentLogPath := filepath.Join(dir, "output_log_2026-02-21_00-00-00.txt")
+	if err := os.WriteFile(currentLogPath, []byte(""), 0o600); err != nil {
+		t.Fatalf("write current log: %v", err)
+	}
+
+	lw, err := NewLogWatcher(currentLogPath)
+	if err != nil {
+		t.Fatalf("new watcher: %v", err)
+	}
+	defer lw.Stop()
+
+	newLogCh := make(chan string, 1)
+	lw.OnNewLogFile = func(path string) {
+		select {
+		case newLogCh <- path:
+		default:
+		}
+	}
+
+	if err := lw.Start(); err != nil {
+		t.Fatalf("start watcher: %v", err)
+	}
+
+	nonLogPath := filepath.Join(dir, "not_vrchat.log")
+	if err := os.WriteFile(nonLogPath, []byte("ignore me"), 0o600); err != nil {
+		t.Fatalf("write non-log file: %v", err)
+	}
+
+	select {
+	case got := <-newLogCh:
+		t.Fatalf("unexpected new log file detection: %q", got)
+	case <-time.After(500 * time.Millisecond):
+	}
 }


### PR DESCRIPTION
## Summary
- detect newly created `output_log_*.txt` files in the watched directory and expose them via a new `OnNewLogFile` callback
- wire the app watcher generation guard to request a log file switch when a new session log appears, preventing stale-session tailing
- add watcher tests for new-session log detection and for ignoring non-VRChat files

## Testing
- go test ./internal/watcher
- go test ./internal/application