### PR TITLE
Prioritize HJ over MP in position mapping

### DIFF
--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -783,11 +783,11 @@ func positionOrder(n int) []Position {
 	case 5:
 		return []Position{PosSB, PosBB, PosUTG, PosMP, PosBTN}
 	case 6:
-		return []Position{PosSB, PosBB, PosUTG, PosMP, PosCO, PosBTN}
+		return []Position{PosSB, PosBB, PosUTG, PosHJ, PosCO, PosBTN}
 	case 7:
-		return []Position{PosSB, PosBB, PosUTG, PosUTG1, PosMP, PosCO, PosBTN}
+		return []Position{PosSB, PosBB, PosUTG, PosUTG1, PosHJ, PosCO, PosBTN}
 	case 8:
-		return []Position{PosSB, PosBB, PosUTG, PosUTG1, PosMP, PosMP1, PosCO, PosBTN}
+		return []Position{PosSB, PosBB, PosUTG, PosUTG1, PosMP, PosHJ, PosCO, PosBTN}
 	default:
 		result := make([]Position, n)
 		result[0] = PosSB

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -266,7 +266,7 @@ func TestLocalPlayerNotBlind(t *testing.T) {
 }
 
 func TestPositionAssignment(t *testing.T) {
-	// 6-handed: SB=0, BB=1, UTG=2, MP=3, CO=4, BTN=5
+	// 6-handed: SB=0, BB=1, UTG=2, HJ=3, CO=4, BTN=5
 	h := &Hand{
 		SBSeat:      0,
 		BBSeat:      1,
@@ -288,7 +288,7 @@ func TestPositionAssignment(t *testing.T) {
 		0: PosSB,
 		1: PosBB,
 		2: PosUTG,
-		3: PosMP,
+		3: PosHJ,
 		4: PosCO,
 		5: PosBTN,
 	}

--- a/internal/parser/types.go
+++ b/internal/parser/types.go
@@ -47,10 +47,12 @@ const (
 	PosUTG              // Under the Gun
 	PosUTG1             // UTG+1
 	PosMP               // Middle Position
-	PosMP1              // MP+1
+	PosMP1              // Hijack (legacy name: MP+1)
 	PosCO               // Cutoff
 	PosBTN              // Button (Dealer)
 )
+
+const PosHJ Position = PosMP1
 
 func (p Position) String() string {
 	switch p {
@@ -65,7 +67,7 @@ func (p Position) String() string {
 	case PosMP:
 		return "MP"
 	case PosMP1:
-		return "MP+1"
+		return "HJ"
 	case PosCO:
 		return "CO"
 	case PosBTN:

--- a/internal/persistence/migrations/00003_backfill_hj_position.go
+++ b/internal/persistence/migrations/00003_backfill_hj_position.go
@@ -1,0 +1,33 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/pressly/goose/v3"
+
+	"github.com/AkatukiSora/vrc-vrpoker-ststs/internal/parser"
+)
+
+func init() {
+	goose.AddMigrationContext(Up00003, Down00003)
+}
+
+func Up00003(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `UPDATE hand_players
+		SET position = ?
+		WHERE position = ?
+			AND EXISTS (
+				SELECT 1 FROM hands
+				WHERE hands.hand_uid = hand_players.hand_uid
+					AND hands.num_players IN (6, 7)
+			)`, int(parser.PosHJ), int(parser.PosMP)); err != nil {
+		return fmt.Errorf("backfill hj position for 6/7-max hands: %w", err)
+	}
+	return nil
+}
+
+func Down00003(context.Context, *sql.Tx) error {
+	return nil
+}

--- a/internal/persistence/migrations/00003_backfill_hj_position_test.go
+++ b/internal/persistence/migrations/00003_backfill_hj_position_test.go
@@ -1,0 +1,81 @@
+package migrations
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/AkatukiSora/vrc-vrpoker-ststs/internal/parser"
+	_ "modernc.org/sqlite"
+)
+
+func TestUp00003BackfillsMPToHJForSixAndSevenMax(t *testing.T) {
+	t.Parallel()
+
+	db, err := sql.Open("sqlite", ":memory:")
+	if err != nil {
+		t.Fatalf("open sqlite: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx, nil)
+	if err != nil {
+		t.Fatalf("begin tx: %v", err)
+	}
+
+	ddl := []string{
+		`CREATE TABLE hands (hand_uid TEXT PRIMARY KEY, num_players INTEGER NOT NULL);`,
+		`CREATE TABLE hand_players (hand_uid TEXT NOT NULL, seat_id INTEGER NOT NULL, position INTEGER NOT NULL, PRIMARY KEY(hand_uid, seat_id));`,
+	}
+	for _, q := range ddl {
+		if _, err := tx.ExecContext(ctx, q); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("create test schema: %v", err)
+		}
+	}
+
+	fixtures := []struct {
+		handUID    string
+		numPlayers int
+		position   parser.Position
+		wantPos    parser.Position
+	}{
+		{handUID: "h6", numPlayers: 6, position: parser.PosMP, wantPos: parser.PosHJ},
+		{handUID: "h7", numPlayers: 7, position: parser.PosMP, wantPos: parser.PosHJ},
+		{handUID: "h8", numPlayers: 8, position: parser.PosMP, wantPos: parser.PosMP},
+		{handUID: "h6-utg", numPlayers: 6, position: parser.PosUTG, wantPos: parser.PosUTG},
+	}
+
+	for i, f := range fixtures {
+		if _, err := tx.ExecContext(ctx, `INSERT INTO hands(hand_uid, num_players) VALUES(?, ?)`, f.handUID, f.numPlayers); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("insert hand %d: %v", i, err)
+		}
+		if _, err := tx.ExecContext(ctx, `INSERT INTO hand_players(hand_uid, seat_id, position) VALUES(?, ?, ?)`, f.handUID, i, int(f.position)); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("insert hand_player %d: %v", i, err)
+		}
+	}
+
+	if err := Up00003(ctx, tx); err != nil {
+		_ = tx.Rollback()
+		t.Fatalf("run migration: %v", err)
+	}
+
+	for i, f := range fixtures {
+		var got int
+		if err := tx.QueryRowContext(ctx, `SELECT position FROM hand_players WHERE hand_uid = ? AND seat_id = ?`, f.handUID, i).Scan(&got); err != nil {
+			_ = tx.Rollback()
+			t.Fatalf("query hand_player %d: %v", i, err)
+		}
+		if parser.Position(got) != f.wantPos {
+			_ = tx.Rollback()
+			t.Fatalf("hand %s got position=%v want=%v", f.handUID, parser.Position(got), f.wantPos)
+		}
+	}
+
+	if err := tx.Commit(); err != nil {
+		t.Fatalf("commit tx: %v", err)
+	}
+}

--- a/internal/ui/hand_range.go
+++ b/internal/ui/hand_range.go
@@ -55,7 +55,7 @@ var positionFilters = []struct {
 	{Key: "utg", LabelKey: "hand_range.filter.utg", LabelFallback: "UTG", Pos: parser.PosUTG},
 	{Key: "utg1", LabelKey: "hand_range.filter.utg1", LabelFallback: "UTG+1", Pos: parser.PosUTG1},
 	{Key: "mp", LabelKey: "hand_range.filter.mp", LabelFallback: "MP", Pos: parser.PosMP},
-	{Key: "mp1", LabelKey: "hand_range.filter.mp1", LabelFallback: "MP+1", Pos: parser.PosMP1},
+	{Key: "mp1", LabelKey: "hand_range.filter.mp1", LabelFallback: "HJ", Pos: parser.PosHJ},
 	{Key: "co", LabelKey: "hand_range.filter.co", LabelFallback: "CO", Pos: parser.PosCO},
 	{Key: "btn", LabelKey: "hand_range.filter.btn", LabelFallback: "BTN", Pos: parser.PosBTN},
 }

--- a/internal/ui/position_stats.go
+++ b/internal/ui/position_stats.go
@@ -18,8 +18,8 @@ import (
 var positionDisplayOrder = []parser.Position{
 	parser.PosBTN,
 	parser.PosCO,
-	parser.PosMP1,
 	parser.PosMP,
+	parser.PosHJ,
 	parser.PosUTG1,
 	parser.PosUTG,
 	parser.PosBB,

--- a/internal/ui/translations/en.json
+++ b/internal/ui/translations/en.json
@@ -249,7 +249,7 @@
   "hand_range.filter.utg": "UTG",
   "hand_range.filter.utg1": "UTG+1",
   "hand_range.filter.mp": "MP",
-  "hand_range.filter.mp1": "MP+1",
+  "hand_range.filter.mp1": "HJ",
   "hand_range.filter.co": "CO",
   "hand_range.filter.btn": "BTN",
 

--- a/internal/ui/translations/ja.json
+++ b/internal/ui/translations/ja.json
@@ -249,7 +249,7 @@
   "hand_range.filter.utg": "UTG",
   "hand_range.filter.utg1": "UTG+1",
   "hand_range.filter.mp": "MP",
-  "hand_range.filter.mp1": "MP+1",
+  "hand_range.filter.mp1": "HJ",
   "hand_range.filter.co": "CO",
   "hand_range.filter.btn": "BTN",
 


### PR DESCRIPTION
## Summary
- Align parser position assignment with poker convention by treating 6/7-max middle seat as HJ and keeping 8-max as MP + HJ.
- Normalize UI labels/order so position views consistently show `MP` then `HJ` and display HJ instead of legacy MP+1.
- Add a SQLite migration to backfill existing 6/7-max `MP` rows to `HJ`, with migration tests to protect data integrity.